### PR TITLE
fix: increase component width to prevent text truncation

### DIFF
--- a/apps/web/components/docs-preview-wrapper.tsx
+++ b/apps/web/components/docs-preview-wrapper.tsx
@@ -398,7 +398,7 @@ export function DocsPreviewWrapper({
             ref={variantBarRef}
             role="tablist"
             aria-label="Preview variants"
-            className="pointer-events-auto flex max-w-[min(100vw-2rem,28rem)] items-center gap-0.5 overflow-x-auto rounded-2xl border border-border/40 bg-white/75 p-1 shadow-[0_8px_32px_rgba(0,0,0,0.08)] backdrop-blur-xl dark:border-white/[0.06] dark:bg-[#121212]/80 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+            className="pointer-events-auto flex max-w-[min(100vw-2rem,36rem)] items-center gap-0.5 overflow-x-auto rounded-2xl border border-border/40 bg-white/75 p-1 shadow-[0_8px_32px_rgba(0,0,0,0.08)] backdrop-blur-xl dark:border-white/[0.06] dark:bg-[#121212]/80 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
           >
             {!hideDefaultVariant && (
               <PreviewVariantTab


### PR DESCRIPTION
This pull request fixes the rendering issue where the circuit board had a network topology with got cut off.

I increased the rem from 28 to 36.

before

<img width="618" height="100" alt="image" src="https://github.com/user-attachments/assets/685b4398-5754-46dd-85f3-70aa679933a6" />

after 

<img width="697" height="102" alt="image" src="https://github.com/user-attachments/assets/c9a12a9f-652c-40f0-80a0-ec939532a107" />


this is in refrence to issue #9 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Expanded the maximum width of the documentation preview variant selector for improved visibility in wider viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->