### PR TITLE
fix(showcase): remove fixed grid rows to prevent layout stretching on devtools resize

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -155,7 +155,7 @@ export default function Home() {
                 hidden: {},
                 visible: { transition: { staggerChildren: 0.06 } },
               }}
-              className="mb-20 mt-10 grid w-full min-w-0 auto-rows-[min(300px,70vw)] grid-cols-1 gap-2.5 md:mt-12 md:auto-rows-[300px] md:grid-cols-4 md:grid-rows-3"
+              className="mb-20 mt-10 grid w-full min-w-0 auto-rows-[min(300px,70vw)] grid-cols-1 gap-2.5 md:mt-12 md:auto-rows-[300px] md:grid-cols-4"
             >
               {/* Card 1: 1x1 Dark */}
               <motion.div


### PR DESCRIPTION
Fixes an issue where the home showcase section (`data-home-showcase`) expanded infinitely in height when toggling DevTools or resizing the viewport below 992px.

## Root Cause
The showcase grid wrapper had both `md:grid-rows-3` and `md:auto-rows-[300px]` applied simultaneously. When Framer Motion triggered the `whileInView` animations upon viewport re-calculation (e.g., opening DevTools), implicit grid items exceeded the fixed row bounds, causing continuous element layout recalculations and breaking regular page scrolling.

## Changes Made
- Removed `md:grid-rows-3` from the showcase `<motion.div>` grid container.
- Allowed CSS Grid to handle implicit row additions dynamically via `md:auto-rows-[300px]`.

## How to Reproduce the Issue
1. Navigate to the Home page on the main branch (or live site).
2. Open Browser DevTools
3. Set the viewport width to below **992px**.
4. Scroll down until the `data-home-showcase` section
5. Notice how the showcase container expands vertically uncontrollably, stretching the entire page height and breaking scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the responsive showcase grid layout for improved consistency across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->