### PR TITLE
fix(styles): add cursor pointer for non-disabled buttons globally

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -320,6 +320,10 @@ body:has([data-blocks-layout])::-webkit-scrollbar,
   height: 0;
 }
 
+button:not(:disabled) {
+  cursor: pointer;
+}
+
 .usage-code-scrollbar-none * {
   -ms-overflow-style: none;
   scrollbar-width: none;


### PR DESCRIPTION
## Summary
Adds a global `cursor: pointer` style to non-disabled buttons in `globals.css`. 

This gives users clear hover feedback on all interactive elements across the site, making the UI feel much more responsive and natural to navigate.

## Changes
- Applied `cursor: pointer` globally to `button:not(:disabled)` in `globals.css`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated interactive buttons to display a pointer cursor when they are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->