### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,19 +167,19 @@ See [LICENSE](./LICENSE) for more information.
 - Powered by [Vercel](https://vercel.com/)
 
 <p align="center">
-  <a href="https://star-history.com/#harshjdhv/componentry&Date">
+  <a href="https://star-history.dera.page/#harshjdhv/componentry&Date">
     <picture>
       <source
         media="(prefers-color-scheme: dark)"
-        srcset="https://api.star-history.com/svg?repos=harshjdhv/componentry&type=Date&theme=dark&legend=top-left"
+        srcset="https://star-history.dera.page/svg?repos=harshjdhv/componentry&type=Date&theme=dark&legend=top-left"
       />
       <source
         media="(prefers-color-scheme: light)"
-        srcset="https://api.star-history.com/svg?repos=harshjdhv/componentry&type=Date&legend=top-left"
+        srcset="https://star-history.dera.page/svg?repos=harshjdhv/componentry&type=Date&legend=top-left"
       />
       <img
         alt="Star History Chart"
-        src="https://api.star-history.com/svg?repos=harshjdhv/componentry&type=Date&legend=top-left"
+        src="https://star-history.dera.page/svg?repos=harshjdhv/componentry&type=Date&legend=top-left"
       />
     </picture>
   </a>


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub's stargazer API restrictions, so the contribution history no longer renders. This update switches the chart to a working provider so it displays correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Acknowledgments star-history chart links to use the current hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->